### PR TITLE
fix: posts stays at 800px even when screen-width less.

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,6 +6,9 @@
 .logo__cursor {
 	display: none;
 }
+.posts  {
+	max-width: 100%;
+}
 .post {
 	width: 800px;
 	max-width: 100%;


### PR DESCRIPTION
This could be done in two ways:
- constrain .posts to have a `max-width: 100%` too
- set the .post to have a max width of `100vw` instead of `100%`.

I chose the former.