### PR TITLE
fix: header content width on _index.md

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,10 +6,11 @@
 .logo__cursor {
 	display: none;
 }
-.posts  {
-	max-width: 100%;
+.index-content {
+	padding: 0 20px;
 }
-.post {
+.content {
+	margin: 50px auto;
 	width: 800px;
 	max-width: 100%;
 }


### PR DESCRIPTION
We switch to setting the width on the .content class instead of .posts and friends.