### PR TITLE
fix: regression with width of post listings (oops).

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,3 +15,6 @@
 	width: 800px;
 	max-width: 100%;
 }
+.posts {
+	width: 100%;
+}


### PR DESCRIPTION
although the containing wrapper is the proper size, we also need to make sure the posts always wrap to be the max size of the container.